### PR TITLE
Address Type Resolution Issues in Legacy Migration Using log4j-1.2-api with OpenJDK Compilation

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/Logger.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/Logger.java
@@ -30,7 +30,7 @@ public class Logger extends Category {
      */
     private static final String FQCN = Logger.class.getName();
 
-    public static Logger getLogger(final Class<?> clazz) {
+    public static Logger getLogger(@SuppressWarnings("rawtypes") final Class clazz) {
         // Depth 2 gets the call site of this method.
         return LogManager.getLogger(clazz.getName(), StackLocatorUtil.getCallerClassLoader(2));
     }


### PR DESCRIPTION
This Pull Request addresses a type resolution issue that occurs when compiling legacy code using log4j-1.2-api with OpenJDK. 
The problem arises from a subtle difference in method signatures between the getLogger methods defined in org.apache.log4j.Logger provided by log4j-1.2-api and the original log4j library.

# Root Cause
The discrepancy lies in the method signatures of getLogger:

1. log4j-1.2-api defines it as: [Source](https://github.com/apache/logging-log4j2/blob/2.x/log4j-1.2-api/src/main/java/org/apache/log4j/Logger.java#L33)
```java
public static Logger getLogger(final Class<?> clazz)
```

 
2. Original log4j defines it as: [Source](https://github.com/apache/logging-log4j1/blob/main/src/main/java/org/apache/log4j/Logger.java#L116)
```java
public static Logger getLogger(final Class clazz)
```

This difference becomes problematic when dealing with legacy code that includes custom Logger classes extending the original org.apache.log4j.Logger.

# Example of Affected Legacy Code

Consider a custom MyLogger class:
```java
public class MyLogger extends org.apache.log4j.Logger {
  protected MyLogger(String name) {
    super(name);
  }
  public static MyLogger getLogger(Class clazz) {
    return (MyLogger) Logger.getLogger(clazz.getName());
  }
}
```

Used in code like this:
```java
public class MyObject {
  static final MyLogger logger = MyLogger.getLogger(MyObject.class);
}
```

When compiling with Java 21, the following error occurs:

    [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile (default-compile) on project log4j-app: Compilation failure
    [ERROR] /C:/work/java/xxxx/zzzzz/src/main/java/zzzzz/foo/bar/MyObject.java:[5,58] incompatible types: org.apache.log4j.Logger cannot be converted to zzzzz.foo.bar.MyLogger

This error occurs because the getLogger method in MyLogger lacks a type parameter, causing the compiler to select the getLogger method from org.apache.log4j.Logger instead.

# Verification

To confirm this, modifying the MyLogger class as follows resolves the compilation issue:
```java
public class MyLogger extends org.apache.log4j.Logger {
  protected MyLogger(String name) {
    super(name);
  }
  public static MyLogger getLogger(Class<?> clazz) {
    return (MyLogger) Logger.getLogger(clazz.getName());
  }
}
```

This Pull Request implements a solution to address this type resolution problem, ensuring compatibility between legacy code using custom Logger extensions and the log4j-1.2-api library when compiling with OpenJDK.

# Note
While we can rebuild the source code in our project, we cannot modify the existing legacy code itself.
